### PR TITLE
Allow root nesting for newer non-SemVer watchman versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ class WatchPreference {
   watchmanWorks(details) {
     this._watchmanInfo.enabled = true;
     this._watchmanInfo.version = details.version;
-    this._watchmanInfo.canNestRoots = semver.satisfies(details.version, '>= 3.7.0');
+    this._watchmanInfo.canNestRoots = details.canNestRoots;
   }
 
   get watchmanInfo() {


### PR DESCRIPTION
Prevent root nesting to be false for newer non-SemVer watchman versions 