### PR TITLE
Watch nested addons when using new Watchman versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const tmp = require('tmp');
-const semver = require('semver');
 const SilentError = require('silent-error');
 
 const POLLING = 'polling';
@@ -26,7 +25,7 @@ class WatchPreference {
   watchmanWorks(details) {
     this._watchmanInfo.enabled = true;
     this._watchmanInfo.version = details.version;
-    this._watchmanInfo.canNestRoots = semver.satisfies(details.version, '>= 3.7.0');
+    this._watchmanInfo.canNestRoots = true;
   }
 
   get watchmanInfo() {
@@ -223,7 +222,6 @@ class WatchDetector {
 
       result.watchmanWorks({
         version,
-        canNestRoots: true,
       });
 
       return result;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "heimdalljs-logger": "^0.1.10",
-    "semver": "^6.3.0",
     "silent-error": "^1.1.1",
     "tmp": "^0.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,7 +2942,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-semver@6.3.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
+semver@6.3.0, semver@^6.1.0, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
Similar to https://github.com/ember-cli/watch-detector/pull/13, the semver check here is no longer valid and was preventing newer versions of Watchman from properly watching nested addons.

This was the last remaining usage of `semver` so I've also removed it from `package.json`.

Fixes https://github.com/ember-cli/watch-detector/issues/25.