### PR TITLE
Update link to watchman docs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const WATCHMAN = 'watchman';
 const NODE = 'node';
 const EVENTS = 'events';
 const POSSIBLE_WATCHERS = [POLLING, WATCHMAN, NODE, EVENTS];
-const WATCHMAN_INFO = 'Visit https://ember-cli.com/user-guide/#watchman for more info.';
+const WATCHMAN_INFO = 'Visit https://cli.emberjs.com/release/basic-use/#whyiswatchmanneeded for more info.';
 
 const debug = require('heimdalljs-logger')('ember-cli:watcher');
 


### PR DESCRIPTION
The existing link doesn't work anymore. This new link seems to be the best spot in the current docs.

(It also seems weird to me that this is where the link lives and it's not parametrizable but I guess ember-cli is the only consumer of this package.)