### PR TITLE
Update URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "watch-detector",
   "version": "1.0.1",
   "description": "",
-  "homepage": "https://github.com/chrmod/watch-detector#readme",
+  "homepage": "https://github.com/ember-cli/watch-detector#readme",
   "bugs": {
-    "url": "https://github.com/chrmod/watch-detector/issues"
+    "url": "https://github.com/ember-cli/watch-detector/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chrmod/watch-detector.git"
+    "url": "git+https://github.com/ember-cli/watch-detector.git"
   },
   "license": "MIT",
   "files": [


### PR DESCRIPTION
The metadata still points to the old repository. Although GitHub does the redirect for us, might as well point to the proper place.